### PR TITLE
Hyperlink Formatting

### DIFF
--- a/docs/status.rst
+++ b/docs/status.rst
@@ -29,13 +29,13 @@ account that was first to successfully submit the block header to BTC Relay.
 What is the fee for previous blocks?
 =============================
 
-Use `getFeeAmount(). <https://github.com/ethereum/btcrelay/tree/master#getfeeamountblockhash>`_
+Use `getFeeAmount(). [https://github.com/ethereum/btcrelay/tree/master#getfeeamountblockhash]
 
 
 What can I do if the fee is too high?
 =============================
 
-An option is to `changeFeeRecipient() <https://github.com/ethereum/btcrelay/tree/master#changefeerecipientblockhash-fee-recipient>`_
+An option is to `changeFeeRecipient() [https://github.com/ethereum/btcrelay/tree/master#changefeerecipientblockhash-fee-recipient]
 to yourself.  Make sure you satisfy all requirements for successful completion.
 
 


### PR DESCRIPTION
Hyperlink Formatting: In the sections "What is the fee for previous blocks?" and "What can I do if the fee is too high?", the hyperlinks are not formatted correctly for plain text. It's better to provide the full URL next to the text it's meant to link. For example:

For the fee for previous blocks, use getFeeAmount(): [https://github.com/ethereum/btcrelay/tree/master#getfeeamountblockhash]
To change the fee recipient, use changeFeeRecipient(): [https://github.com/ethereum/btcrelay/tree/master#changefeerecipientblockhash-fee-recipient]